### PR TITLE
Adjust CowgirlSquattingLetGo.xml for heel support

### DIFF
--- a/meshes/0SA/mod/0Sex/scene/OpS/LyBKne/Sx/CowgirlSquattingLetGo.xml
+++ b/meshes/0SA/mod/0Sex/scene/OpS/LyBKne/Sx/CowgirlSquattingLetGo.xml
@@ -39,7 +39,7 @@
 <metadata tags="cowgirl"/>
 <actors>
 	<actor position="0" penisAngle="0" feetOnGround="0" tags="lyingback" lookUp="25"/>
-	<actor position="1" feetOnGround="1" tags="squatting" lookUp="-80"/>
+	<actor position="1" feetOnGround="0" tags="squatting" lookUp="-80"/>
 </actors>
 <actions>
 	<action type="vaginalsex" actor="0" target="1" performer="1"/>


### PR DESCRIPTION
Due to feetOnGround being set to 1, heels were causing misalignment.